### PR TITLE
typo: `nixpgs` -> `nixpkgs`

### DIFF
--- a/src/Nix_Flakes_Explained_4.md
+++ b/src/Nix_Flakes_Explained_4.md
@@ -201,7 +201,7 @@ Example:
 
 ```nix
 nix repl
-nix-repl> :l <nixpgs>
+nix-repl> :l <nixpkgs>
 nix-repl> lib.genAttrs [ "boom" "bash" ] (name: "sonic" + namd)
 ```
 


### PR DESCRIPTION
Hello,

Thanks for this documentation, here's a PR fixing a very minor things I saw while browsing.